### PR TITLE
Add links to open stacktrace items in RubyMine using IntelliJ REST API

### DIFF
--- a/content_scripts/better.css
+++ b/content_scripts/better.css
@@ -1,5 +1,5 @@
 code {
-    background-color: rgba(220, 220, 220, .5);
+    background-color: rgb(241, 241, 241);
     border-radius: 3px;
     box-decoration-break: clone;
     font-family: Menlo, "Bitstream Vera Sans Mono", "Ubuntu Mono", "Courier New", Courier, consolas, "Liberation Mono", monospace;
@@ -42,4 +42,20 @@ a.betterpreview:hover {
     border: 1px dotted #c0c0c0;
     border-radius: 3px;
     padding: 2px;
+}
+
+.better-intellij-link:hover {
+    text-decoration: none;
+}
+
+.better-intellij-link::after {
+    margin: 0 .5em;
+    content: "\21af";
+    background-color: #e5f4ff;
+    border-radius: .5em;
+    padding: 0 0.4em;
+}
+
+.better-intellij-link:hover::after {
+    background-color: rgb(180, 223, 255);
 }

--- a/content_scripts/better.js
+++ b/content_scripts/better.js
@@ -8,6 +8,7 @@
 const CANARY = 'canary',
     PREVIEW_CLASS_BEFORE = 'better',
     PREVIEW_CLASS_AFTER = 'betterpreview',
+    INTELLIJ_LINK_CLASS = 'better-intellij-link'
     MEDIA_PNG = 'png',
     MEDIA_MP4 = 'mp4';
 
@@ -31,8 +32,8 @@ const OVERVIEW_TRANSFORMS = [
     },
     {
         // language=JSRegexp
-        from: '(features\/[\\w_\/]+\.feature:\\d+)',
-        to: '<code>$1</code>',
+        from: '(?:\\.\\/)?([\\.\\w_\\/]+:\\d+)\\:in',
+        to: `<code>$1</code><a href="#" class="${INTELLIJ_LINK_CLASS}" data-path="$1" title="Open file in IDE"></a>`,
         flags: 'g'
     },
     {
@@ -201,6 +202,15 @@ function select_code(event) {
     }
 }
 
+function open_in_intellij(event) {
+    const link = `http://localhost:63342/api/file/${event.target.dataset.path}`
+
+    const req = new XMLHttpRequest();
+    req.open("GET", link);
+    req.send();
+    event.preventDefault();
+}
+
 function transform_node_text(text, transformers) {
     transformers.forEach((item) => {
         let rex = new RegExp(item.from, item.flags);
@@ -236,6 +246,10 @@ function transform_mutated_nodes(transformer_class, rules, customizer) {
 
     Array.from(document.getElementsByTagName('code')).forEach((item) => {
         item.addEventListener('dblclick', select_code, false)
+    });
+    
+    Array.from(document.getElementsByClassName(INTELLIJ_LINK_CLASS)).forEach((item) => {
+        item.addEventListener('click', open_in_intellij, false)
     });
 }
 


### PR DESCRIPTION
Path matching is implemented for Cucumber and RubyMine. A link is created next to each matched stacktrace item. Clicking link will open the file in IntelliJ based IDE.

Note that IDE will show alert asking if you trust the source. To make IDE open file immediately check `Allow unsigned request` in `Debugger` preferences in IDE. Warning: this lessens security.